### PR TITLE
Fix HPM proxy request error for e2e tests and fix post service spec

### DIFF
--- a/client/e2e/src/doorboard.e2e-spec.ts
+++ b/client/e2e/src/doorboard.e2e-spec.ts
@@ -11,10 +11,10 @@ describe('Owner Doorboard', () => {
   });
 
   it('Should have the correct title', () => {
-    expect(page.getPageTitle()).toEqual('Rachael Johnson');
+    expect(page.getPageTitle()).toEqual('Rachel Johnson');
   });
 
-  it('Should have the correct first post', async() => {
+  it('Should have the correct first post', async () => {
     page.getOwnerListItems().first();
     expect(element(by.className('post-card')).getText()).toEqual(
       'I\'m going to be a few minutes late to my office hours today. I got caught in traffic this morning.');

--- a/client/e2e/src/doorboard.po.ts
+++ b/client/e2e/src/doorboard.po.ts
@@ -1,6 +1,7 @@
 import {browser, by, element, Key, ElementFinder} from 'protractor';
 
 export class DoorBoard {
+  // navigates to Rachel Johnson's doorboard
   navigateTo() {
     return browser.get('/owner/588935f57546a2daea44de7c/posts');
   }

--- a/client/e2e/src/owner-list.e2e-spec.ts
+++ b/client/e2e/src/owner-list.e2e-spec.ts
@@ -16,6 +16,8 @@ describe('Owner list', () => {
 
   it('Should type something in the name filter and check that it returned correct elements', async () => {
     await page.typeInput('owner-name-input', 'Robert Denton');
+    // added this here to stop the proxy request errors from trying to grab things before typeInput had finished
+    await browser.wait(EC.urlContains('/owners'), 10000);
 
     // All of the owner cards should have the name we are filtering by
     page.getOwnerCards().each(e => {
@@ -34,12 +36,13 @@ describe('Owner list', () => {
 
   it('Should type something partial in the name filter and check that it returned correct elements', async () => {
     await page.typeInput('owner-name-input', 'ch');
+    await browser.wait(EC.urlContains('/owners'), 10000);
 
     // Go through each of the cards that are being shown and get the names
     const names = await page.getOwnerCards().map(e => e.element(by.className('owner-card-name')).getText());
 
     // We should see these names
-    expect(names).toContain('Rachael Johnson');
+    expect(names).toContain('Rachel Johnson');
     expect(names).toContain('Indrajit Chaudhury');
 
     // We shouldn't see these names
@@ -49,6 +52,7 @@ describe('Owner list', () => {
 
   it('Should type something in the building filter and check that it returned correct elements', async () => {
     await page.typeInput('owner-building-input', 'science');
+    await browser.wait(EC.urlContains('/owners'), 10000);
 
     // Go through each of the cards that are being shown and get the building names
     const buildings = await page.getOwnerCards().map(e => e.element(by.className('owner-card-building')).getText());
@@ -60,29 +64,6 @@ describe('Owner list', () => {
     expect(buildings).not.toContain('Camden');
     expect(buildings).not.toContain('The Moon');
   });
-
-  // no longer applicable, keeping it for future reference
-
-  // it('Should change the view', async () => {
-  //   await page.changeView('list');
-
-  //   expect(page.getOwnerCards().count()).toEqual(0); // There should be no cards
-  //   expect(page.getOwnerListItems().count()).toBeGreaterThan(0); // There should be list items
-  // });
-
-  // it('Should select a role, switch the view, and check that it returned correct elements', async () => {
-  //   await page.selectMatSelectValue('owner-role-select', 'viewer');
-  //   await page.changeView('list');
-
-  //   expect(page.getOwnerListItems().count()).toBeGreaterThan(0);
-
-  //   // All of the owner list items should have the role we are looking for
-  //   page.getOwnerListItems().each(e => {
-  //     expect(e.element(by.className('owner-list-role')).getText()).toEqual('viewer');
-  //   });
-
-
-  // });
 
   it('Should click view doorboard on a owner and go to the right URL', async () => {
 
@@ -100,11 +81,6 @@ describe('Owner list', () => {
     const url = await page.getUrl();
     expect(RegExp('/owner/[0-9a-fA-F]{24}/posts$', 'i').test(url)).toBe(true);
 
-    // On this profile page we were sent to, the name and company should be correct
-    /*expect(element(by.className('owner-card-name')).getText()).toEqual(firstOwnerName);
-    expect(element(by.className('owner-card-building')).getText()).toEqual(firstOwnerBuilding);
-    expect(element(by.className('owner-card-officeID')).getText()).toEqual(firstOwnerOfficeID);
-    expect(element(by.className('owner-card-email')).getText()).toEqual(firstOwnerEmail);*/
   });
 
   it('Should click add owner and go to the right URL', async () => {

--- a/client/src/app/posts/post.service.spec.ts
+++ b/client/src/app/posts/post.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { Post } from './post';
 import { PostService } from './post.service';
+import { request } from 'http';
 
 describe('Post service: ', () => {
   const testPosts: Post[] = [
@@ -50,12 +51,16 @@ describe('Post service: ', () => {
 
   it('getOwnerPosts() calls api/posts', () => {
     postService.getOwnerPosts({ owner_id: '588935f57546a2daea44de7c' }).subscribe(
-      posts => expect(posts).toBe(testPosts)
+      posts => expect(posts).toEqual(testPosts)
     );
     // not sure about this test
     const req = httpTestingController.expectOne(
       (request) => request.url.startsWith(postService.postUrl) && request.params.has('owner_id')
     );
+
+    expect(req.request.method).toEqual('GET');
+    expect(req.request.params.get('owner_id')).toEqual('588935f57546a2daea44de7c');
+    req.flush(testPosts);
   });
 
   it('addPost() calls api/owner/:id/posts/new', () => {

--- a/client/src/testing/post.service.mock.ts
+++ b/client/src/testing/post.service.mock.ts
@@ -33,7 +33,6 @@ export class MockPostService extends PostService {
   }
   // should be tested in the doorboard component spec
   getOwnerPosts(filters: { owner_id?: string }): Observable<Post[]> {
-    // Just return the test posts regardless of what filters are passed in
     return of(MockPostService.testPosts);
   }
 

--- a/database/seed/owners.json
+++ b/database/seed/owners.json
@@ -3,7 +3,7 @@
     "_id": {
       "$oid": "588935f57546a2daea44de7c"
     },
-    "name": "Rachael Johnson",
+    "name": "Rachel Johnson",
     "officeID": "1310",
     "email": "rmjohns@morris.umn.edu",
     "building": "Science"


### PR DESCRIPTION
The getOwnerPosts test in post service spec was previously not expecting anything and was essentially not a test.